### PR TITLE
Swap protocol expression in nftables

### DIFF
--- a/cake-qos-simple.nft
+++ b/cake-qos-simple.nft
@@ -84,8 +84,8 @@ table inet cake-qos-simple {
 
 	chain store-dscp-in-conntrack {
 
-                ip version 4 ct mark set (@nh,8,8 & 252) >> 2
-                ip6 version 6 ct mark set (@nh,0,16 & 4032) >> 6
+                meta nfproto ipv4 ct mark set (@nh,8,8 & 252) >> 2
+                meta nfproto ipv6 ct mark set (@nh,0,16 & 4032) >> 6
                 ct mark set ct mark or 128
         }
 }


### PR DESCRIPTION
In store-dscp-in-conntrack chain, using ip version and ip6 version expressions is less efficent than using meta nfproto.

This is not a significant performance improvement, but this is the more common representation of protocol filtering in firewall4.

Compare the number of netlink register operations required for old and new.
```
$ nft -c --debug=netlink add rule 'inet cake-qos-simple \ store-dscp-in-conntrack ip version 4 ct mark set (@nh,8,8 & 252) >> 2'

inet cake-qos-simple store-dscp-in-conntrack
  [ meta load nfproto => reg 1 ]
  [ cmp eq reg 1 0x00000002 ]
  [ payload load 1b @ network header + 0 => reg 1 ]
  [ bitwise reg 1 = ( reg 1 & 0x000000f0 ) ^ 0x00000000 ]
  [ cmp eq reg 1 0x00000040 ]
  [ payload load 1b @ network header + 1 => reg 1 ]
  [ bitwise reg 1 = ( reg 1 & 0x000000fc ) ^ 0x00000000 ]
  [ bitwise reg 1 = ( reg 1 >> 0x00000002 ) ]
  [ ct set mark with reg 1 ]

$ nft -c --debug=netlink add rule 'inet cake-qos-simple \ store-dscp-in-conntrack meta nfproto ipv4 ct mark set (@nh,8,8 & 252) >> 2'

inet cake-qos-simple store-dscp-in-conntrack
  [ meta load nfproto => reg 1 ]
  [ cmp eq reg 1 0x00000002 ]
  [ payload load 1b @ network header + 1 => reg 1 ]
  [ bitwise reg 1 = ( reg 1 & 0x000000fc ) ^ 0x00000000 ]
  [ bitwise reg 1 = ( reg 1 >> 0x00000002 ) ]
  [ ct set mark with reg 1 ]

$ nft -c --debug=netlink add rule 'inet cake-qos-simple \ store-dscp-in-conntrack ip6 version 6 ct mark set (@nh,0,16 & 4032) >> 6'

inet cake-qos-simple store-dscp-in-conntrack
  [ meta load nfproto => reg 1 ]
  [ cmp eq reg 1 0x0000000a ]
  [ payload load 1b @ network header + 0 => reg 1 ]
  [ bitwise reg 1 = ( reg 1 & 0x000000f0 ) ^ 0x00000000 ]
  [ cmp eq reg 1 0x00000060 ]
  [ payload load 2b @ network header + 0 => reg 1 ]
  [ bitwise reg 1 = ( reg 1 & 0x0000c00f ) ^ 0x00000000 ]
  [ byteorder reg 1 = ntoh(reg 1, 2, 2) ]
  [ bitwise reg 1 = ( reg 1 >> 0x00000006 ) ]
  [ ct set mark with reg 1 ]

$ nft -c --debug=netlink add rule 'inet cake-qos-simple \ store-dscp-in-conntrack meta nfproto ipv6 ct mark set (@nh,0,16 & 4032) >> 6'

inet cake-qos-simple store-dscp-in-conntrack
  [ meta load nfproto => reg 1 ]
  [ cmp eq reg 1 0x0000000a ]
  [ payload load 2b @ network header + 0 => reg 1 ]
  [ bitwise reg 1 = ( reg 1 & 0x0000c00f ) ^ 0x00000000 ]
  [ byteorder reg 1 = ntoh(reg 1, 2, 2) ]
  [ bitwise reg 1 = ( reg 1 >> 0x00000006 ) ]
  [ ct set mark with reg 1 ]
```