### PR TITLE
Reset qdiscs on service start

### DIFF
--- a/cake-qos-simple
+++ b/cake-qos-simple
@@ -52,7 +52,7 @@ EXTRA_HELP="
 start()
 {
 	printf "Setting up ingress handle for interface: '${ul_if}'.\n"
-	SILENT=1 tc qdisc del dev "${ul_if}" handle ffff: ingress
+	tc qdisc del dev "${ul_if}" handle ffff: ingress >/dev/null 2>&1
 	tc qdisc add dev "${ul_if}" handle ffff: ingress
 
 	# If no dl_if specified, then create appropriate IFB and redirect ingress on $ul_if thereto
@@ -77,7 +77,7 @@ start()
 	fi
 
 	printf "\nSetting up CAKE on interface: '${ul_if}' with bandwidth: '${cake_ul_rate_Mbps}Mbit/s' and options: '${cake_ul_options}'.\n"
-	SILENT=1 tc qdisc del dev "${ul_if}" root
+	tc qdisc del dev "${ul_if}" root >/dev/null 2>&1
 	tc qdisc add dev "${ul_if}" root handle 1: cake bandwidth "${cake_ul_rate_Mbps}Mbit" ${cake_ul_options}
 
 	printf "\nSetting up tc filter to restore DSCPs from conntrack on egress packets on interface '${ul_if}'.\n"
@@ -91,7 +91,7 @@ start()
 	fi
 
 	printf "\nSetting up CAKE on interface: '${dl_if}' with bandwidth: '${cake_dl_rate_Mbps}Mbit/s' and options: '${cake_dl_options}'.\n"
-	SILENT=1 tc qdisc del dev "${dl_if}" root
+	tc qdisc del dev "${dl_if}" root >/dev/null 2>&1
 	tc qdisc add dev "${dl_if}" root handle 1: cake bandwidth "${cake_dl_rate_Mbps}Mbit" ${cake_dl_options}
 
 	if [[ -n "${overwrite_ecn_val_dl}" ]]

--- a/cake-qos-simple
+++ b/cake-qos-simple
@@ -52,6 +52,7 @@ EXTRA_HELP="
 start()
 {
 	printf "Setting up ingress handle for interface: '${ul_if}'.\n"
+	SILENT=1 tc qdisc del dev "${ul_if}" handle ffff: ingress
 	tc qdisc add dev "${ul_if}" handle ffff: ingress
 
 	# If no dl_if specified, then create appropriate IFB and redirect ingress on $ul_if thereto
@@ -76,6 +77,7 @@ start()
 	fi
 
 	printf "\nSetting up CAKE on interface: '${ul_if}' with bandwidth: '${cake_ul_rate_Mbps}Mbit/s' and options: '${cake_ul_options}'.\n"
+	SILENT=1 tc qdisc del dev "${ul_if}" root
 	tc qdisc add dev "${ul_if}" root handle 1: cake bandwidth "${cake_ul_rate_Mbps}Mbit" ${cake_ul_options}
 
 	printf "\nSetting up tc filter to restore DSCPs from conntrack on egress packets on interface '${ul_if}'.\n"
@@ -89,6 +91,7 @@ start()
 	fi
 
 	printf "\nSetting up CAKE on interface: '${dl_if}' with bandwidth: '${cake_dl_rate_Mbps}Mbit/s' and options: '${cake_dl_options}'.\n"
+	SILENT=1 tc qdisc del dev "${dl_if}" root
 	tc qdisc add dev "${dl_if}" root handle 1: cake bandwidth "${cake_dl_rate_Mbps}Mbit" ${cake_dl_options}
 
 	if [[ -n "${overwrite_ecn_val_dl}" ]]


### PR DESCRIPTION
Hi, this may be one of preference, but in service start, deleting the qdiscs before adding them saves having to run service stop first and also gives consistant behaviour.

Thoughts?