### PR TITLE
Fixed for DSL / PPPoE users thats getting reversed speeds by default

### DIFF
--- a/cake-qos-simple
+++ b/cake-qos-simple
@@ -91,8 +91,13 @@ gen_config()
 	cake_ul_rate_Mbps=20  # cake upload rate in Mbit/s
 	cake_dl_rate_Mbps=20 # cake download rate in Mbit/s
 
+	# WAN
 	cake_ul_options="diffserv4 triple-isolate nat wash ack-filter noatm overhead 0"
 	cake_dl_options="diffserv4 triple-isolate nat nowash ingress no-ack-filter noatm overhead 0"
+
+	# For DSL routers or pppoe-wan interfaces, Choice this option.
+	#cake_ul_options="diffserv4 dual-srchost nonat wash no-ack-filter split-gso rtt 100ms pppoe-ptm ether-vlan noatm"
+	#cake_dl_options="diffserv4 dual-dsthost nonat nowash ingress no-ack-filter split-gso rtt 100ms noatm overhead 34"
 
 	overwrite_ul_ect_0_val="" # overwrite upload ECT(1) values with decimal value (e.g. 0, 1, 2, 3), else "" to disable
 	overwrite_ul_ect_1_val="" # overwrite upload ECT(0) values with decimal value (e.g. 0, 1, 2, 3), else "" to disable


### PR DESCRIPTION
By default for them that are on DSL / PPPoE will face a issue with it seen reversed.
This change wil work fine for them that are on either DSL / PPPoE.

```
cake_ul_options="diffserv4 dual-srchost nonat wash ack-filter split-gso rtt 100ms pppoe-ptm ether-vlan noatm"
cake_dl_options="diffserv4 dual-dsthost nonat nowash ingress no-ack-filter split-gso rtt 100ms noatm overhead 34"
```

Please make any changes to `cake_dl_options=` that suits a better approach for DSL users, However is recommend by https://allysmith.uk/vdsl2-overheads) for UK openreach FTTC/VDSL2.

Thanks to @moeller0 for the ack-filter tip :) 